### PR TITLE
fix localstorage issue for private browsing

### DIFF
--- a/public/lib/duel.js
+++ b/public/lib/duel.js
@@ -49,7 +49,15 @@
    */
   duel.isLocalStorageAvailable = function () {
     try {
-      return 'localStorage' in window && window['localStorage'] !== null && window['localStorage'] !== undefined;
+      var hasStorage = typeof localStorage !== 'undefined' && ('setItem' in localStorage) && localStorage.setItem;
+      if (!hasStorage) {
+        return false;
+      }
+
+      var uid = new Date;
+      localStorage.setItem(uid, uid);
+      localStorage.removeItem(uid);
+      return true;
     } catch (e) {
       return false;
     }


### PR DESCRIPTION
At least localStorage is present in private browsing but call `setItem` will throw a DOM Exception 22.

I've changed the check to call `setItem`. If `setItem` is supported a call to `removeItem` is made to remove the change. In case of private browsing the catch block will be called as before.

